### PR TITLE
Use RFCs and ADRs to record decisions

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+## Code of Conduct
+
+This project follows the ['alphagov' Github organisation's Code of Conduct]
+(https://github.com/alphagov/code-of-conduct).

--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ There are 2 types of documentation:
   allow us and the wider community to suggest and refine ideas.
 - [Decision Records](/decision-records), which document decisions that have been
   made, along with any context.
+
+## Code of Conduct
+
+This project follows the ['alphagov' Github organisation's Code of Conduct]
+(https://github.com/alphagov/code-of-conduct).

--- a/README.md
+++ b/README.md
@@ -2,3 +2,17 @@
 
 We use this repository as a forum to discuss and record technical decisions that
 affect the products supported by the GOV.UK Design System team, including:
+
+- GOV.UK Design System
+- GOV.UK Frontend
+- GOV.UK Prototype Kit
+
+This repository is open to enable involvement from the wider community and as a
+reference for other teams within GDS and wider government.
+
+There are 2 types of documentation:
+
+- [Proposals](/proposals), often referred to as 'requests for comments', which
+  allow us and the wider community to suggest and refine ideas.
+- [Decision Records](/decision-records), which document decisions that have been
+  made, along with any context.

--- a/decision-records/000-template.md
+++ b/decision-records/000-template.md
@@ -1,0 +1,20 @@
+# Decision Record Title
+<!-- The title should be a short present tense imperative phrase, less than 50
+     characters, like a git commit message. -->
+
+**Date:** <!-- YYYY-MM-DD -->
+
+**Status:** <!-- proposed, accepted, rejected, deprecated, superseded -->
+
+## Context
+
+<!-- What is the issue that we're seeing that is motivating this decision or
+     change. -->
+
+## Decision
+
+<!-- What is the change that we're actually proposing or doing. -->
+
+## Consequences
+
+<!-- What becomes easier or more difficult to do because of this change. -->

--- a/decision-records/README.md
+++ b/decision-records/README.md
@@ -1,0 +1,22 @@
+# Decision Records
+
+Records of the architectural decisions that affect one or more of our products.
+
+These records could reflect the outcomes of the accepted proposals but they
+might also reflect ad-hoc decisions or decisions made without going through the
+RFC process.
+
+## Process
+
+1. Create a new branch on this repository and copy
+   `decision-records/000-template.md` to a new file with the next free number,
+   such as `001-my-decision-record.md`.
+2. Modify the template to add detail about the decision.
+3. Include any images etc in a separate directory with the same name as your
+   record (`000-my-decision-record`) and link to them.
+4. Make a Pull Request (PR) for your branch.
+5. The record will be reviewed. As decision records are documenting a decision
+   that has already been made, any reviews should be focus on ensuring that the
+   documentation is clear and understandable. If you disagree with the decision,
+   you should raise a proposal instead.
+6. Once approved using the Github review system, the PR can be merged.

--- a/proposals/000-template.md
+++ b/proposals/000-template.md
@@ -1,0 +1,19 @@
+# Proposal Title
+
+**Closing date:** <!-- YYYY-MM-DD. Ideally allow at least 7 days -->
+
+**Status:** <!-- proposed, accepted, rejected, superseded -->
+
+## Summary
+
+<!-- An abstract, tl;dr or executive summary of your proposal. -->
+
+## Problem
+
+<!-- Describe the problem your proposal is trying to solve. -->
+
+## Proposal
+
+<!-- Describe your proposal, with a focus on clarity of meaning. If it helps,
+     you MAY use [RFC2119-style](https://www.ietf.org/rfc/rfc2119.txt) MUST,
+     SHOULD and MAY language to help clarify your intentions. -->

--- a/proposals/001-use-rfcs-and-adrs-to-discuss-proposals-and-record-decisions.md
+++ b/proposals/001-use-rfcs-and-adrs-to-discuss-proposals-and-record-decisions.md
@@ -15,7 +15,7 @@ We need to make and record decisions in the open, because:
 - it will help us to answer questions from our users as to why things are the
   way they are
 - it makes it less likely that approaches will be changed in the future without
-  a full understanding of the context or the rational for the original decision
+  a full understanding of the context or the rationale for the original decision
 - it provides a valuable resource to others, both in government and the wider
   community, who are embarking on similar projects
 

--- a/proposals/001-use-rfcs-and-adrs-to-discuss-proposals-and-record-decisions.md
+++ b/proposals/001-use-rfcs-and-adrs-to-discuss-proposals-and-record-decisions.md
@@ -43,3 +43,8 @@ We will aim to simplify the language where possible to reduce the barrier of
 entry to contribution and involvement. For example, we will refer to RFCs as
 proposals unless we are talking specifically about the format used; we will
 simplify 'architecture decision records' to 'decision records'.
+
+## Related links
+
+- [Inspiration: React RFCs](https://github.com/reactjs/rfcs)
+- [Inspiration: Swift Evolution](https://github.com/apple/swift-evolution)

--- a/proposals/001-use-rfcs-and-adrs-to-discuss-proposals-and-record-decisions.md
+++ b/proposals/001-use-rfcs-and-adrs-to-discuss-proposals-and-record-decisions.md
@@ -1,0 +1,45 @@
+# Use RFCs and ADRs to discuss proposals and record decisions
+
+**Closing date:** 2018-03-16
+**Status:** Proposed
+
+## Summary
+
+Use the Request for Comments (RFC) and Architecture Decision Record (ADR)
+formats to discuss and record technical decisions for the products we support.
+
+## Problem
+
+We need to make and record decisions in the open, because:
+
+- it will help us to answer questions from our users as to why things are the
+  way they are
+- it makes it less likely that approaches will be changed in the future without
+  a full understanding of the context or the rational for the original decision
+- it provides a valuable resource to others, both in government and the wider
+  community, who are embarking on similar projects
+
+Whilst some of this is recorded in documents in e.g. Google Drive, this is
+not publicly available; there is no consistent approach to how this
+documentation is written; and there is no consistent approach to how it is
+filed.
+
+## Proposal
+
+We will create a new public repository on GitHub
+(`alphagov/govuk-design-system-architecture`) as a place to discuss proposals
+and record decisions.
+
+We will use a simplified version of the existing Request for Comments (RFC)
+publication format as a platform for suggesting and refining ideas whilst
+involving the wider community.
+
+We will use the existing Architecture Decision Records (ARD) publication format
+as a way to document decisions that have been made.
+
+We will use markdown for both of these publication types.
+
+We will aim to simplify the language where possible to reduce the barrier of
+entry to contribution and involvement. For example, we will refer to RFCs as
+proposals unless we are talking specifically about the format used; we will
+simplify 'architecture decision records' to 'decision records'.

--- a/proposals/001-use-rfcs-and-adrs-to-discuss-proposals-and-record-decisions.md
+++ b/proposals/001-use-rfcs-and-adrs-to-discuss-proposals-and-record-decisions.md
@@ -1,7 +1,7 @@
 # Use RFCs and ADRs to discuss proposals and record decisions
 
 **Closing date:** 2018-03-16
-**Status:** Proposed
+**Status:** Accepted
 
 ## Summary
 

--- a/proposals/001-use-rfcs-and-adrs-to-discuss-proposals-and-record-decisions.md
+++ b/proposals/001-use-rfcs-and-adrs-to-discuss-proposals-and-record-decisions.md
@@ -34,7 +34,7 @@ We will use a simplified version of the existing Request for Comments (RFC)
 publication format as a platform for suggesting and refining ideas whilst
 involving the wider community.
 
-We will use the existing Architecture Decision Records (ARD) publication format
+We will use the existing Architecture Decision Records (ADR) publication format
 as a way to document decisions that have been made.
 
 We will use markdown for both of these publication types.

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -1,0 +1,45 @@
+# Proposals
+
+Most changes to GOV.UK Design System, GOV.UK Frontend or GOV.UK Prototype Kit
+can be implemented and reviewed via the normal GitHub pull request workflow
+without raising a proposal.
+
+Where changes would represent a substantial change to the architecture of a
+product or the way the products work together we would expect a proposal to be
+raised to gather feedback from the community and to ensure that the consequences
+of the change are fully thought-out.
+
+## Process
+
+1. Create a new branch on this repository and copy `proposals/000-template.md`
+   to a new file with the next free number, such as `001-my-proposal.md`.
+2. Modify the template to add detail about your proposal.
+3. Include any images etc in a separate directory with the same name as your
+   proposal (`000-my-proposal`) and link to them.
+4. Make a Pull Request (PR) for your branch.
+5. Post a link to your PR in #govuk-design-system channel on Slack.
+6. The Design System team and the wider community are able to discuss your
+   proposal using both inline comments against your document and the general PR
+   comments section. You will need to create a free GitHub account in order to
+   comment.
+7. As changes are requested and agreed in comments, make the changes in your RFC
+   and push them as new commits.
+8. Stay active in the discussion and encourage and remind other relevant people
+   to participate. If you start a proposal it’s up to you to push it through the
+   process and engage people.
+9. Once consensus is reached and approvals given using the Github review system,
+   the PR can be merged.
+
+## Rejecting proposals
+
+A proposal can be rejected. This can happen if a consensus isn’t reached, or
+people agree rejecting it is the right thing to do. In this case the PR should
+be closed with a suitable comment.
+
+## Recording changes
+
+Proposals should be considered an immutable record of a point in time. If we
+want to change a decision that was made in a previous proposal, a new proposal
+should be raised. If that proposal is accepted, the old proposal may be updated
+to reflect the fact that it has been superseded, but should otherwise be left
+intact.

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -32,9 +32,12 @@ of the change are fully thought-out.
 
 ## Rejecting proposals
 
-A proposal can be rejected. This can happen if a consensus isn’t reached, or
-people agree rejecting it is the right thing to do. In this case the PR should
-be closed with a suitable comment.
+A proposal can be rejected by the Design System team. This can happen for many
+reasons, including if a consensus isn’t reached, or if people agree that
+rejecting it is the right thing to do. It might be that there are already plans
+to address a given problem in a different way, or that it's just not the right
+time to make the change. In this case the PR should be closed with a suitable
+comment.
 
 ## Recording changes
 


### PR DESCRIPTION
Bootstrap this repo by proposing it into existence!

The first commit is the proposal itself, the second commit is the proposed implementation.

This is loosely based on [alphagov/govuk-rfcs](https://github.com/alphagov/govuk-rfcs) as well as other internal RFC repos, adapting them to make them more suitable for a RFC process where we expect feedback from a wider community.

This proposal will remain open until 16 March 2018.