### PR TITLE
Fix code of conduct links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,5 @@
 ## Code of Conduct
 
-This project follows the ['alphagov' Github organisation's Code of Conduct]
-(https://github.com/alphagov/code-of-conduct).
+This project follows the ['alphagov' GitHub organisation Code of Conduct][coc].
+
+[coc]: https://github.com/alphagov/code-of-conduct

--- a/README.md
+++ b/README.md
@@ -19,5 +19,6 @@ There are 2 types of documentation:
 
 ## Code of Conduct
 
-This project follows the ['alphagov' Github organisation's Code of Conduct]
-(https://github.com/alphagov/code-of-conduct).
+This project follows the ['alphagov' GitHub organisation Code of Conduct][coc].
+
+[coc]: https://github.com/alphagov/code-of-conduct


### PR DESCRIPTION
Fix markdown link formatting issue; correctly capitalise ‘GitHub’.